### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ config: ## Configure and update build files
 
 mwnci: ${AST} ${EVAL} ${LEXER} ${OBJECT} ${PARSER} ${TOKEN} ${TYPING} mwnci.go ## Build mwnci for current architecture
 	@echo "Building mwnci"
-	CGO_ENABLED=0 go build -ldflags="-X main.version=${VERSION}"
+	GO111MODULE=on CGO_ENABLED=0 go build -ldflags="-X main.version=${VERSION}"
 
 build: ## Configure and compile mwnci
 	@make config

--- a/includes/main_darwin.mwnci
+++ b/includes/main_darwin.mwnci
@@ -1,0 +1,1 @@
+// Darwin (macOS) specific includes

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -41,8 +41,12 @@ func Start(in io.Reader, out io.Writer) {
 	})
 	defer rl.Close()
 	var cmds []string
+	var err error
 	for {
-		line, _ = rl.Readline()
+		line, err = rl.Readline()
+		if err != nil {
+			break
+		}
 		line = strings.TrimSpace(line)
 		if len(line) == 0 {
 			continue


### PR DESCRIPTION
Minor fixes  
-  specify go modules being used when running go build
- add include for darwin to allow running on macOS (may need implementation)
- break on error from repl to allow ctrl c to exit (maybe check error?)